### PR TITLE
feat: allow symfony6, handling of different function definition of ha…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^7.2|^8.0",
         "behat/mink":  "^1.7",
-        "symfony/phpunit-bridge": "^4.4|^5.0"
+        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0"
     },
 
     "require-dev": {
-        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "phpunit/phpunit": "^8.5"
     },
 

--- a/src/AbstractFixturesKernel.php
+++ b/src/AbstractFixturesKernel.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Util;
+
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+abstract class AbstractFixturesKernel implements HttpKernelInterface
+{
+    protected function handleFixtureRequest(Request $request): Response
+    {
+        $fixturesDir = realpath(__DIR__.'/../web-fixtures');
+        $overwriteDir = realpath(__DIR__.'/../http-kernel-fixtures');
+
+        require_once $fixturesDir . '/utils.php';
+
+        $file = $request->getPathInfo();
+
+        $path = file_exists($overwriteDir.$file) ? $overwriteDir.$file : $fixturesDir.$file;
+
+        $resp = null;
+
+        ob_start();
+        require $path;
+        $content = ob_get_clean();
+
+        if ($resp instanceof Response) {
+            if ('' === $resp->getContent()) {
+                $resp->setContent($content);
+            }
+
+            return $resp;
+        }
+
+        return new Response($content);
+    }
+
+    protected function prepareSession(Request $request)
+    {
+        $session = new Session(new MockFileSessionStorage());
+        $request->setSession($session);
+
+        $cookies = $request->cookies;
+
+        if ($cookies->has($session->getName())) {
+            $session->setId($cookies->get($session->getName()));
+        } else {
+            $session->migrate(false);
+        }
+    }
+
+    protected function saveSession(Request $request, Response $response)
+    {
+        $session = $request->getSession();
+        if ($session && $session->isStarted()) {
+            $session->save();
+
+            $params = session_get_cookie_params();
+
+            if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
+                $cookie = Cookie::create($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+            } else {
+                $cookie = new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+            }
+
+            $response->headers->setCookie($cookie);
+        }
+    }
+}

--- a/src/FixturesKernel.php
+++ b/src/FixturesKernel.php
@@ -2,85 +2,18 @@
 
 namespace Behat\Mink\Tests\Driver\Util;
 
-
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
-class FixturesKernel implements HttpKernelInterface
+if(Kernel::VERSION_ID < 50000)
 {
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
-    {
-        $this->prepareSession($request);
-
-        $response = $this->handleFixtureRequest($request);
-
-        $this->saveSession($request, $response);
-        $response->prepare($request);
-
-        return $response;
-    }
-
-    private function handleFixtureRequest(Request $request)
-    {
-        $fixturesDir = realpath(__DIR__.'/../web-fixtures');
-        $overwriteDir = realpath(__DIR__.'/../http-kernel-fixtures');
-
-        require_once $fixturesDir . '/utils.php';
-
-        $file = $request->getPathInfo();
-
-        $path = file_exists($overwriteDir.$file) ? $overwriteDir.$file : $fixturesDir.$file;
-
-        $resp = null;
-
-        ob_start();
-        require $path;
-        $content = ob_get_clean();
-
-        if ($resp instanceof Response) {
-            if ('' === $resp->getContent()) {
-                $resp->setContent($content);
-            }
-
-            return $resp;
-        }
-
-        return new Response($content);
-    }
-
-    private function prepareSession(Request $request)
-    {
-        $session = new Session(new MockFileSessionStorage());
-        $request->setSession($session);
-
-        $cookies = $request->cookies;
-
-        if ($cookies->has($session->getName())) {
-            $session->setId($cookies->get($session->getName()));
-        } else {
-            $session->migrate(false);
-        }
-    }
-
-    private function saveSession(Request $request, Response $response)
-    {
-        $session = $request->getSession();
-        if ($session && $session->isStarted()) {
-            $session->save();
-
-            $params = session_get_cookie_params();
-
-            if (method_exists('Symfony\Component\HttpFoundation\Cookie', 'create')) {
-                $cookie = Cookie::create($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
-            } else {
-                $cookie = new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
-            }
-
-            $response->headers->setCookie($cookie);
-        }
-    }
+    // Symfony < 5
+    class FixturesKernel extends FixturesKernelLegacy implements HttpKernelInterface
+    {}
+}
+else
+{
+    // Symfony >= 5
+    class FixturesKernel extends FixturesKernelSymfony5 implements HttpKernelInterface
+    {}
 }

--- a/src/FixturesKernelLegacy.php
+++ b/src/FixturesKernelLegacy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Util;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class FixturesKernelLegacy extends AbstractFixturesKernel implements HttpKernelInterface
+{
+    # TODO remove if symfony 5 support is dropped
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
+    {
+        $this->prepareSession($request);
+
+        $response = $this->handleFixtureRequest($request);
+
+        $this->saveSession($request, $response);
+        $response->prepare($request);
+
+        return $response;
+    }
+}

--- a/src/FixturesKernelSymfony5.php
+++ b/src/FixturesKernelSymfony5.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Util;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class FixturesKernelSymfony5 extends AbstractFixturesKernel implements HttpKernelInterface
+{
+    # TODO change $type to self::MAIN_REQUEST with symfony >= 7
+    public function handle(Request $request, int $type = self::MASTER_REQUEST, bool $catch = true): Response
+    {
+        $this->prepareSession($request);
+
+        $response = $this->handleFixtureRequest($request);
+
+        $this->saveSession($request, $response);
+        $response->prepare($request);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
…ndle()

Hi,

i try to allow symfony6 and handle the changes in the function definition of handle() in HttpKernelInterface
[4.4](https://github.com/symfony/http-kernel/blob/4.4/HttpKernelInterface.php#L47)
[5.0](https://github.com/symfony/http-kernel/blob/5.0/HttpKernelInterface.php#L47)

This is a blocker for this PR.
https://github.com/FriendsOfBehat/MinkBrowserKitDriver/pull/10

Please have a look at it. Needs Review and Testing.
Maybe there is an better and easier solution to make that happen.

Greetz